### PR TITLE
Remove nonexistant sethome function

### DIFF
--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -21,7 +21,7 @@ const Home = (props) => {
         <Link to={{
           pathname:`/visualizations/${user}`
         }}>
-          <button aria-label="Search for user" className="search-btn" onClick={() => props.setHome(false)}>grow</button>
+          <button aria-label="Search for user" className="search-btn">grow</button>
         </Link>
       </div>
       {!clicked && <h2 className="or">OR</h2>}


### PR DESCRIPTION
Set home was still declared in the Home component even though we removed the home state from the navigation. This was causing an error sometimes.
