### PR TITLE
Adjust styling and add color key hover

### DIFF
--- a/src/components/ColorKey/ColorKey.css
+++ b/src/components/ColorKey/ColorKey.css
@@ -1,59 +1,3 @@
-.slideout-color-key-toggler {
-  position: fixed;
-  bottom: 0;
-  left: 45vw;
-  width: 0;
-  height: 0;
-  border-left: 3vh solid transparent;
-  border-right: 3vh solid transparent;
-  border-bottom: 3vh solid black;
-  padding: 50px 0px 20px 10px;
-  /* background: grey; */
-  /* border-radius: 0% 50% 50% 0%;
-  border-right: 2px solid #ffdbbc; */
-  text-align: left;
-  font-size: 10px;
-  color: #ffdbbc;
-  -webkit-transition-duration: 0.4s;
-  -moz-transition-duration: 0.4s;
-  -o-transition-duration: 0.4s;
-  transition-duration: 0.4s;
-  -webkit-border-radius: 0 5px 5px 0;
-  -moz-border-radius: 0 5px 5px 0;
-}
-
-  .slideout-color-key_inner {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    position: fixed;
-    bottom: -68vh;
-    left: 0;
-    height: 70vh;
-    width: 100vw;
-    background: black;
-    padding: 25px;
-    font-size: 16px;
-    font-style: normal;
-    -webkit-transition-duration: 0.4s;
-    -moz-transition-duration: 0.4s;
-    -o-transition-duration: 0.4s;
-    transition-duration: 0.4s;
-    text-align: left;
-    -webkit-border-radius: 0 0 5px 0;
-    -moz-border-radius: 0 0 5px 0;
-    border-radius: 0 0 5px 0;
-  }
-
-  .slideout-color-key-toggler:hover {
-    bottom: 7vh;
-    cursor: pointer;
-  }
-  .slideout-color-key-toggler:hover .slideout-color-key_inner {
-    bottom: 0;
-  }
-
   .color-pairs {
     display: flex;
   }
@@ -68,7 +12,7 @@
     justify-content: flex-start;
     align-items: center;
     width: 75px;
-    margin-top: 0;
+    margin-top: 40px;
     margin-right: 5px;
   }
 

--- a/src/components/Garden/Garden.js
+++ b/src/components/Garden/Garden.js
@@ -6,7 +6,7 @@ const Garden = (props) => {
 
   const repositories = props.data;
 
-  const gardenWidth = 120 * repositories.length;
+  const gardenWidth = 110 * repositories.length;
   const view = `0 0 ${200 * repositories.length} 800`
 
   const drawGarden = () => {

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -21,7 +21,7 @@ const Home = (props) => {
         <Link to={{
           pathname:`/visualizations/${user}`
         }}>
-          <button aria-label="Search for user" className="search-btn" onClick={() => props.setHome(false)}>grow</button>
+          <button aria-label="Search for user" className="search-btn">grow</button>
         </Link>
       </div>
       {!clicked && <h2 className="or">OR</h2>}

--- a/src/components/ProfileVisualization.js
+++ b/src/components/ProfileVisualization.js
@@ -1,0 +1,170 @@
+import React, { useState, useEffect } from 'react';
+import { Link } from "react-router-dom";
+import Garden from './Garden.js';
+import ErrorPage from './ErrorPage'
+import ProfileLoader from './ProfileLoader'
+import ColorKey from './ColorKey'
+import FlowerKey from './FlowerKey'
+import './ProfileVisualization.css';
+import pvAPI from './ProfileVisualizationApi';
+import gardenHat from './hat.png'
+
+const ProfileVisualization = (props) => {
+  const [userGitHubData, setUserGitHubData] = useState('')
+  const [cleanUserData, setCleanUserData] = useState([]);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [newUserNameToSearch, setNewUserNameToSearch] = useState('');
+  const [error, setError] = useState(false);
+  const [gitHubError, setGitHubError] = useState("");
+
+  const loadUser = async () => {
+    try {
+      const userPromise = await pvAPI.fetchGitHubData(`https://api.github.com/users/${props.userNameToSearch}`);
+      const userData = await userPromise.json();
+      setUserGitHubData(userData);
+      return userData;
+    } catch (err) {
+      setGitHubError(err)
+    }
+  }
+
+  const getLifespans = (filteredRepos) => {
+    const oneDayInMilliseconds = 1000 * 60 * 60 * 24;
+    const repoAges = filteredRepos.map(repo => {
+      const creationDate = new Date(repo.created_at).getTime();
+      const lastUpdate = new Date(repo.updated_at).getTime();
+      const repoAge = (lastUpdate - creationDate) / oneDayInMilliseconds
+      return repoAge.toFixed(0)
+    })
+    return repoAges;
+  }
+
+  const fetchRepoContributor = async (user, userRepos) => {
+    const userName = user.login;
+    const repoContainsUser = await Promise.all(
+      userRepos.map(async repo => {
+        try {
+          const contributorsPromise = await pvAPI.fetchGitHubData(`${repo.contributors_url}`);
+          const contributorsList = await contributorsPromise.json();
+          const contributorNames = contributorsList.map(person => person.login);
+          return contributorNames.includes(userName);
+        } catch(err) {
+          setError(err)
+        }
+      })
+    );
+    const filteredUserRepos = userRepos.filter((repo, index) => repoContainsUser[index]);
+    return filteredUserRepos
+  }
+
+  const loadRepos = async () => {
+    try {
+      const userPromise = await pvAPI.fetchGitHubData(`https://api.github.com/users/${props.userNameToSearch}/repos?per_page=100`);
+      const repoData = await userPromise.json();
+      return repoData
+    } catch (err) {
+      setError(err)
+    }
+  }
+
+  const getLanguages = async (filteredRepos) => {
+    const languages = await Promise.all(
+      filteredRepos.map(async repo => {
+        try {
+          const languagesPromise = await pvAPI.fetchGitHubData(`${repo.url}/languages`);
+          const languagesData = await languagesPromise.json();
+          const languagesList = [];
+          let languageLines = 0;
+          for (let language in languagesData) {
+            languagesList.push(language)
+            languageLines += languagesData[language]
+          }
+          return [...languagesList, languageLines]
+        } catch(err) {
+          setError(err)
+        }
+      }
+    )
+  );
+    return languages
+  }
+
+  const getBranchNames = async (filteredRepos) => {
+    const repoBranches = await Promise.all(
+      filteredRepos.map(async repo => {
+        try {
+          const branchesPromise = await pvAPI.fetchGitHubData(`https://api.github.com/repos/${props.userNameToSearch}/${repo.name}/branches`);
+          const branches = await branchesPromise.json();
+          return branches
+        } catch(err) {
+          setError(err)
+        }
+      })
+    );
+    const namesOfBranches = repoBranches.map(repo => {
+      const names = repo.map(branch => branch.name);
+      return names
+    })
+    return namesOfBranches
+  }
+
+  const consolidateData = (filteredRepos, branchNames, lifespans, repoLangs) => {
+    const cleanedUserData = filteredRepos.map((repo, index) => {
+      return {
+        name: repo.name,
+        branches: branchNames[index],
+        lifespan: lifespans[index] === 0 ? 1 : lifespans[index],
+        languages: repoLangs[index]
+      }
+    })
+    return cleanedUserData;
+  }
+
+  useEffect(() => {
+    const loadUserInformation = async () => {
+      const userGitHub = await loadUser();
+      if (!userGitHub.message) {
+        const usersRepos = await loadRepos();
+        const filteredByContributorUserRepos = await fetchRepoContributor(userGitHub, usersRepos);
+        const branchNames = await getBranchNames(filteredByContributorUserRepos)
+        const languages = await getLanguages(filteredByContributorUserRepos);
+        const lifespans = getLifespans(filteredByContributorUserRepos);
+        const consolidatedData = consolidateData(filteredByContributorUserRepos, branchNames, lifespans, languages);
+        setCleanUserData(consolidatedData);
+        setTimeout(() => {setIsLoaded(true)}, 4000);
+      } else {
+        await setError(true)
+        setIsLoaded(true)
+      }
+    }
+    loadUserInformation();
+  }, [])
+
+  return (
+    <main>
+      {!isLoaded && <ProfileLoader />}
+      {gitHubError && <ErrorPage user={props.userNameToSearch} message={"We couldn't find a profile for"}/>}
+      {isLoaded && !gitHubError &&
+      <>
+        <section className='gardener-info'>
+          <a href={userGitHubData.html_url} target="_blank">
+            <img className="user-profile-pic" src={userGitHubData.avatar_url}/>
+          </a>
+          <h1>Garden of {userGitHubData.name || `@${userGitHubData.login}`}</h1>
+        </section>
+        <section className="user-visualizations-box">
+          {cleanUserData.length > 0 && <Garden data={cleanUserData}/>}
+        </section>
+      </>}
+      <div className="slideout-color-key-toggler">
+        <h3 className="slideout-key_heading">Color Key</h3>
+        <article className="slideout-color-key_inner">
+          <ColorKey />
+          <FlowerKey user={props.userNameToSearch}/>
+        </article>
+      </div>
+    </main>
+  )
+}
+
+export default ProfileVisualization;

--- a/src/components/ProfileVisualization/ProfileVisualization.css
+++ b/src/components/ProfileVisualization/ProfileVisualization.css
@@ -6,12 +6,13 @@
 .slideout-color-key-toggler {
   position: fixed;
   bottom: 0;
-  left: 45vw;
-  width: 50px;
-  height: 120px;
+  left: 2vw;
+  width: 100px;
+  height: 90px;
   background: black;
+  border-radius: 10%;
   text-align: center;
-  font-size: 10px;
+  font-size: 0.6rem;
   color: #ffdbbc;
   -webkit-transition-duration: 0.4s;
   -moz-transition-duration: 0.4s;
@@ -43,6 +44,10 @@
   -webkit-border-radius: 0 0 5px 0;
   -moz-border-radius: 0 0 5px 0;
   border-radius: 0 0 5px 0;
+}
+
+.slideout-key_heading {
+  margin: 5px;
 }
 
 .slideout-color-key-toggler:hover {

--- a/src/components/ProfileVisualization/ProfileVisualization.css
+++ b/src/components/ProfileVisualization/ProfileVisualization.css
@@ -2,6 +2,57 @@
   height: 100px;
   border-radius: 50%;
 }
+
+.slideout-color-key-toggler {
+  position: fixed;
+  bottom: 0;
+  left: 45vw;
+  width: 50px;
+  height: 120px;
+  background: black;
+  text-align: center;
+  font-size: 10px;
+  color: #ffdbbc;
+  -webkit-transition-duration: 0.4s;
+  -moz-transition-duration: 0.4s;
+  -o-transition-duration: 0.4s;
+  transition-duration: 0.4s;
+  -webkit-border-radius: 0 5px 5px 0;
+  -moz-border-radius: 0 5px 5px 0;
+}
+
+.slideout-color-key_inner {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  position: fixed;
+  bottom: -68vh;
+  left: 0;
+  height: 70vh;
+  width: 100vw;
+  background: black;
+  padding: 25px;
+  font-size: 16px;
+  font-style: normal;
+  -webkit-transition-duration: 0.4s;
+  -moz-transition-duration: 0.4s;
+  -o-transition-duration: 0.4s;
+  transition-duration: 0.4s;
+  text-align: left;
+  -webkit-border-radius: 0 0 5px 0;
+  -moz-border-radius: 0 0 5px 0;
+  border-radius: 0 0 5px 0;
+}
+
+.slideout-color-key-toggler:hover {
+  bottom: 7vh;
+  cursor: pointer;
+}
+.slideout-color-key-toggler:hover .slideout-color-key_inner {
+  bottom: 0;
+}
+
 .user-visualizations-box {
   width: 100%;
   height: 60vh;

--- a/src/components/ProfileVisualization/ProfileVisualization.js
+++ b/src/components/ProfileVisualization/ProfileVisualization.js
@@ -158,7 +158,7 @@ const ProfileVisualization = (props) => {
           {cleanUserData.length > 0 && <Garden data={cleanUserData}/>}
         </section>
         <div className="slideout-color-key-toggler">
-          <h3 className="slideout-key_heading">Color Key</h3>
+          <h3 className="slideout-key_heading">Hover for key</h3>
           <article className="slideout-color-key_inner">
             <ColorKey />
             <FlowerKey user={props.userNameToSearch}/>


### PR DESCRIPTION
## Is this a fix or a feature?
- This is a fix

## What is the change/fix?
- The styling on heroku wasn't matching up with the styling on my local host. Turns out after some internet digging my local host was zoomed out to 90%. If you press cmd+0 on a mac it resets your styling to the default. This is why the key looks weird on our deployed version right now. I was styling a zoomed out page.
- I moved the old key stying that was happening in ColorKey to ProfileVisualization because that's where those divs actually exist now. I also edited the key a bit. 
- One thing to note is that the scroll bar is below our hover effect. So if you don't have a trackpad with sidescroll, you literally cannot see any additional flowers because as you try to scroll you just trigger the key. We definitely need a fix. 

## Where should the reviewer start?
- ProfileVisualization.css

## How should this be tested?
- I would pull the branch down and make sure you do cmd+0 to reset your zoom. Make sure everything looks good and that the key hover works the way we intended. 

## Screenshots(if appropriate)

## This PR is related to which issues:
